### PR TITLE
Select custom Rust version due to wasm library inconsistencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,14 +16,21 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        toolchain:
-          - stable
+        toolchain: [1.86.0]
 
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ matrix.toolchain }}
+            override: true
+            components: rustfmt, clippy
+      
       - name: Install wasm32-unknown-unknown target
-        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup target add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
 
       - name: Install Stellar CLI
         uses: stellar/stellar-cli@v22.5.0


### PR DESCRIPTION
# Summary:

This pull request introduces a manual selection of the Rust version. The decision is based on a test failure caused by a third-party dependency that is not maintained by the Rust team, which breaks the pipeline execution.