### PR TITLE
Select specific Rust toolchain version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,17 +17,23 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        toolchain:
-          - stable
+        toolchain: [1.86.0]
 
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ matrix.toolchain }}
+            override: true
+            components: rustfmt, clippy
+
       - name: Install wasm32-unknown-unknown target
-        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup target add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+        
       - name: Install Stellar CLI
         uses: stellar/stellar-cli@v22.5.0
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: "20"


### PR DESCRIPTION
# Summary:

This pull request introduces a manual Rust toolchain setup to address a failing test caused by an external dependency that requires a Rust version lower than 1.87.